### PR TITLE
Update add_deadbolt_permissions_column.php

### DIFF
--- a/database/add_deadbolt_permissions_column.php
+++ b/database/add_deadbolt_permissions_column.php
@@ -13,7 +13,7 @@ class addDeadboltPermissionsColumn extends Migration
     public function up(): void
     {
         Schema::table($this->table, function (Blueprint $table) {
-            $table->json('permissions')->after('id');
+            $table->json('permissions')->after('id')->nullable();
         });
     }
 


### PR DESCRIPTION
Fixes SQLSTATE[HY000]: General error: 1364 Field 'permissions' doesn't have a default value.